### PR TITLE
add elfshaker

### DIFF
--- a/distro.json
+++ b/distro.json
@@ -1,6 +1,6 @@
 {
   "modes" : { 
-    "default" : ["python","file-sync", "openssh","file-sync-ext","environments","ssh-over-http-proxy"]
+    "default" : ["python", "openssh", "environments", "ssh-over-http-proxy", "elfshaker"]
   }
 
   ,"distro": [
@@ -245,48 +245,6 @@
             "sha1": "782c595c1aece9fea8bfa7a14bfbf52e206a0f91",
             "root": "go",
             "path": ["bin"]
-          }
-        }
-      }
-    },
-    {
-      "name": "file-sync",
-      "platforms": {
-        "macos": {
-          "universal": {
-            "url": "https://nxxm.indigenious.io/distro/all/seafile_client/tipi_seafile_client_MacOs.zip",
-            "sha1": "d20a8c574b546801f0964780e612adb69e1f84d4",
-            "root": "tipi_seafile_client",
-            "path": [".","Contents/Resources"]
-          }
-        },
-        "linux": {
-          "universal": {
-            "url": "https://github.com/tipi-build/seafile-build/releases/download/v0.0.1/tipi-v0.0.1-seafile-linux.zip",
-            "sha1": "46a79c6706676ef5289d9b0bc3a7d415104df2d9",
-            "root": "tipi_seafile_client",
-            "path": [".","daemon"]
-          }
-        },
-        "windows": {
-          "universal": {
-            "url": "https://nxxm.indigenious.io/distro/all/seafile_client/tipi_seafile_client_windows.zip",
-            "sha1": "01b125c46bed19ec725984b91aa8ac096ec3c7f2",
-            "root": "tipi_seafile_client",
-            "path": ["deamon/PFiles/Seafile/bin"]
-          }
-        }
-      }
-    },
-    {
-      "name": "file-sync-ext",
-      "platforms": {
-        "windows": {
-          "universal": {
-            "url": "https://github.com/tipi-build/seafile-cli-ext/archive/bc2f92969cd86593862a3b98dc4c8a4dbdf01f8b.zip",
-            "sha1": "2d5f0d8b12716ece815031dcbcd50f72ab95ceba",
-            "root": "seafile-cli-ext-bc2f92969cd86593862a3b98dc4c8a4dbdf01f8b",
-            "path": ["src"]
           }
         }
       }

--- a/distro.json
+++ b/distro.json
@@ -387,6 +387,35 @@
           }
         }
       }
+    },
+    {
+      "name": "elfshaker",
+      "platforms": {
+        "macos": {
+          "universal": {
+            "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.1/elfshaker-macos.zip",
+            "sha1": "2c36957be29ceb17f1bf809d874500bdf3deaa42",
+            "root": "",
+            "path": ["."]
+          }
+        },
+        "linux": {
+          "universal": {
+            "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.1/elfshaker-linux.zip",
+            "sha1": "93fdfa4a52ba365d61f66227c54320c6f72a7d54",
+            "root": "",
+            "path": ["."]
+          }
+        },
+        "windows": {
+          "universal": {
+            "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.1/elfshaker-win.zip",
+            "sha1": "81d18608197690d0dfac0b01dcd006623e99bb8f",
+            "root": "",
+            "path": ["."]
+          }
+        }
+      }
     }
   ]
 }

--- a/distro.json
+++ b/distro.json
@@ -351,24 +351,24 @@
       "platforms": {
         "macos": {
           "universal": {
-            "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.2/elfshaker-macos.zip",
-            "sha1": "3623e398bc571a8418cca8f83611efd3ae86d828",
+            "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.3/elfshaker-macos.zip",
+            "sha1": "a02b7b19977989fb4fa7b6afd05471632b6e1182",
             "root": "",
             "path": ["."]
           }
         },
         "linux": {
           "universal": {
-            "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.2/elfshaker-linux.zip",
-            "sha1": "7294f243133ebaef281b65e1e564776197dcde0f",
+            "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.3/elfshaker-linux.zip",
+            "sha1": "5de78b5e203ebe0a4cb48c0eaea9d51ab0611ca0",
             "root": "",
             "path": ["."]
           }
         },
         "windows": {
           "universal": {
-            "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.2/elfshaker-win.zip",
-            "sha1": "62f26654345eb3cf1b1bd2ba9e34bc5d9f904da3",
+            "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.3/elfshaker-win.zip",
+            "sha1": "9491ad392da6db5f45f35862a6ddb22c19f3bb24",
             "root": "",
             "path": ["."]
           }

--- a/distro.json
+++ b/distro.json
@@ -69,9 +69,9 @@
       "platforms": {
         "all": {
           "universal": {
-            "url": "https://github.com/tipi-build/environments/archive/272adbb3f250ee71a662f05c2aade70b631d443b.zip",
-            "sha1": "088baf59fa10dee69930bab580a224b0f2f23f35",
-            "root": "environments-272adbb3f250ee71a662f05c2aade70b631d443b"
+            "url": "https://github.com/tipi-build/environments/archive/d40aa228196a08d0260454cdb8ba93b8f3c02518.zip",
+            "sha1": "33dc11ff04a796f13c74de07b203f9301472376e",
+            "root": "environments-d40aa228196a08d0260454cdb8ba93b8f3c02518"
           }
         }
       }

--- a/distro.json
+++ b/distro.json
@@ -351,24 +351,24 @@
       "platforms": {
         "macos": {
           "universal": {
-            "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.1/elfshaker-macos.zip",
-            "sha1": "2c36957be29ceb17f1bf809d874500bdf3deaa42",
+            "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.2/elfshaker-macos.zip",
+            "sha1": "3623e398bc571a8418cca8f83611efd3ae86d828",
             "root": "",
             "path": ["."]
           }
         },
         "linux": {
           "universal": {
-            "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.1/elfshaker-linux.zip",
-            "sha1": "93fdfa4a52ba365d61f66227c54320c6f72a7d54",
+            "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.2/elfshaker-linux.zip",
+            "sha1": "7294f243133ebaef281b65e1e564776197dcde0f",
             "root": "",
             "path": ["."]
           }
         },
         "windows": {
           "universal": {
-            "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.1/elfshaker-win.zip",
-            "sha1": "81d18608197690d0dfac0b01dcd006623e99bb8f",
+            "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.2/elfshaker-win.zip",
+            "sha1": "62f26654345eb3cf1b1bd2ba9e34bc5d9f904da3",
             "root": "",
             "path": ["."]
           }

--- a/distro.json
+++ b/distro.json
@@ -352,7 +352,7 @@
         "macos": {
           "universal": {
             "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.3/elfshaker-macos.zip",
-            "sha1": "a02b7b19977989fb4fa7b6afd05471632b6e1182",
+            "sha1": "860ba0f6a91871c583b1770a9b99621d979c616e",
             "root": "",
             "path": ["."]
           }
@@ -360,7 +360,7 @@
         "linux": {
           "universal": {
             "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.3/elfshaker-linux.zip",
-            "sha1": "5de78b5e203ebe0a4cb48c0eaea9d51ab0611ca0",
+            "sha1": "6b441831070e001438d7f85027f317235de97775",
             "root": "",
             "path": ["."]
           }
@@ -368,7 +368,7 @@
         "windows": {
           "universal": {
             "url": "https://github.com/tipi-build/elfshaker/releases/download/v0.0.3/elfshaker-win.zip",
-            "sha1": "9491ad392da6db5f45f35862a6ddb22c19f3bb24",
+            "sha1": "9d06dd80290562f5a703676a6cbc4ca6ef2e38b1",
             "root": "",
             "path": ["."]
           }


### PR DESCRIPTION
This pr is to add elfshaker built by tipi in the distro 
https://github.com/tipi-build/elfshaker/releases/tag/v0.0.1