### PR TITLE
:wrench: fix unsupported target name in cache packs (. is not accepted).

### DIFF
--- a/distro.json
+++ b/distro.json
@@ -69,9 +69,9 @@
       "platforms": {
         "all": {
           "universal": {
-            "url": "https://github.com/tipi-build/environments/archive/9ab14c7f7d23a29c75b092492faf643e67d9db77.zip",
-            "sha1": "6bca602da10766c4595651749a59fa66cfd5b0d7",
-            "root": "environments-9ab14c7f7d23a29c75b092492faf643e67d9db77"
+            "url": "https://github.com/tipi-build/environments/archive/8313053c2080c3b802f403eb78af226ca83feb88.zip",
+            "sha1": "8315ad50dc4888b7ed064bdc31b16a68f04c0731",
+            "root": "environments-8313053c2080c3b802f403eb78af226ca83feb88"
           }
         }
       }


### PR DESCRIPTION
Fix nxxm/nxxm-src#1171