### PR TITLE
support elfshaker name in toolchain

### DIFF
--- a/distro.json
+++ b/distro.json
@@ -69,9 +69,9 @@
       "platforms": {
         "all": {
           "universal": {
-            "url": "https://github.com/tipi-build/environments/archive/9ab14c7f7d23a29c75b092492faf643e67d9db77.zip",
-            "sha1": "6bca602da10766c4595651749a59fa66cfd5b0d7",
-            "root": "environments-9ab14c7f7d23a29c75b092492faf643e67d9db77"
+            "url": "https://github.com/tipi-build/environments/archive/b379f600fcd68c1606fc59d3e39de0d174039917.zip",
+            "sha1": "6aca52b4278517a29e30d746937f11f114ef49ca",
+            "root": "environments-b379f600fcd68c1606fc59d3e39de0d174039917"
           }
         }
       }


### PR DESCRIPTION
the purpose of this pr is to match our toolchain names to our cache generation rules. 