### PR TITLE
CMake Dependency Provider + CMake upgrade to 3.27.6

### DIFF
--- a/distro.json
+++ b/distro.json
@@ -9,28 +9,28 @@
       "platforms": {
         "macos": {
           "x86_64": {
-            "url": "https://nxxm.indigenious.io/distro/all/CMake/v3.21.4/cmake-3.21.4-Darwin-x86_64.zip",
-            "sha1": "1b1b5c6b0db43541f3fa9beaf0885ad52eb63f4f",
-            "root": "cmake-3.21.4-Darwin-x86_64/CMake.app/Contents",
-            "module_path": "share/cmake-3.21/Modules",
+            "url": "https://nxxm.indigenious.io/distro/all/CMake/v3.27.6/cmake-3.27.6-macos-universal.zip",
+            "sha1": "c982bde0e23fc5c74b98c14a93bc63ceef802b2e",
+            "root": "cmake-3.27.6-macos-universal/CMake.app/Contents",
+            "module_path": "share/cmake-3.27/Modules",
             "path": ["bin"]
           } 
         },
         "linux": {
           "x86_64": {
-            "url": "https://nxxm.indigenious.io/distro/all/CMake/v3.21.4/cmake-3.21.4-linux-x86_64.zip",
-            "sha1": "aa668b36aa3e70409a2295e448217f95056f082e",
-            "root": "cmake-3.21.4-linux-x86_64",
-            "module_path": "share/cmake-3.21/Modules",
+            "url": "https://nxxm.indigenious.io/distro/all/CMake/v3.27.6/cmake-3.27.6-linux-x86_64.zip",
+            "sha1": "04ebde3c847eb4dbf06062f059e150f55df6a6d9",
+            "root": "cmake-3.27.6-linux-x86_64",
+            "module_path": "share/cmake-3.27/Modules",
             "path": ["bin"]
           }
         },
         "windows": {
           "x86_64": {
-            "url": "https://nxxm.indigenious.io/distro/all/CMake/v3.21.4/cmake-3.21.4-win64-x64.zip",
-            "sha1": "78da891a6080655bb93b97d9b1c09d6fa8f5b264",
-            "root": "cmake-3.21.4-win64-x64",
-            "module_path": "share/cmake-3.21/Modules",
+            "url": "https://nxxm.indigenious.io/distro/all/CMake/v3.27.6/cmake-3.27.6-windows-x86_64.zip",
+            "sha1": "1dd424e513a34acbde9dfc2c01a9e06dace75239",
+            "root": "cmake-3.27.6-windows-x86_64",
+            "module_path": "share/cmake-3.27/Modules",
             "path": ["bin"]
           }
         }

--- a/distro.json
+++ b/distro.json
@@ -191,6 +191,20 @@
         }
       }
     },
+
+    {
+      "name": "cmake-tipi-provider",
+      "platforms": {
+        "all": {
+          "universal": {
+            "url": "https://github.com/tipi-build/cmake-tipi-provider/archive/1d68b7cf7230f600383409a13e615fc434425750.zip",
+            "sha1": "7e3242805b81aaf16a2eb7644128d24fa10a85be",
+            "root": "cmake-tipi-provider-1d68b7cf7230f600383409a13e615fc434425750"
+          }
+        }
+      }
+    },
+
     {
       "name": "clang",
       "platforms": {


### PR DESCRIPTION
This PR enables the use of https://github.com/tipi-build/cmake-tipi-provider

Which allow to do cmake native dependency management.