### PR TITLE
🔧 add reclient prebuilt package

### DIFF
--- a/distro.json
+++ b/distro.json
@@ -419,6 +419,19 @@
           }
         }
       }
+    },
+    {
+      "name": "reclient",
+      "platforms": {
+        "linux": {
+          "universal": {
+            "url": "https://github.com/tipi-build/distro-reclient/releases/download/v0.0.0/linux-reclient.zip",
+            "sha1": "282eeebd85c434b5f862e8272e820a29416165bd",
+            "root": "",
+            "path": ["linux-reclient"]
+          }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
the purpose of this pr is to add the necessary tools to cmake-re to use the clusters.