### PR TITLE
Add new toolchain vs-17-2022 support

### DIFF
--- a/distro.json
+++ b/distro.json
@@ -71,9 +71,9 @@
       "platforms": {
         "all": {
           "universal": {
-            "url": "https://github.com/tipi-build/environments/archive/7c6ef381540a161e08d7597aae39d47f14d78f44.zip",
-            "sha1": "40a5e6595a8c510f98cb339302286f7fa4ac99fa",
-            "root": "environments-7c6ef381540a161e08d7597aae39d47f14d78f44"
+            "url": "https://github.com/tipi-build/environments/archive/2377a413b5d2a3cf7c3b1094f97a8693f2cfb600.zip",
+            "sha1": "9697f70a14e8ab664d2bf66ddf968ea538aa8fd3",
+            "root": "environments-2377a413b5d2a3cf7c3b1094f97a8693f2cfb600"
           }
         }
       }


### PR DESCRIPTION
the purpose of this pr is to support a new toolchain within our environment in order to allow tipi to build on windows-2022 machines.