### PR TITLE
Upgrade reclient ar vs 17 2022 ubuntu 2404

### DIFF
--- a/distro.json
+++ b/distro.json
@@ -71,9 +71,9 @@
       "platforms": {
         "all": {
           "universal": {
-            "url": "https://github.com/tipi-build/environments/archive/7c6ef381540a161e08d7597aae39d47f14d78f44.zip",
-            "sha1": "40a5e6595a8c510f98cb339302286f7fa4ac99fa",
-            "root": "environments-7c6ef381540a161e08d7597aae39d47f14d78f44"
+            "url": "https://github.com/tipi-build/environments/archive/7df1593053bc3b50bd2ff8acfaec2dd3f4aabbd3.zip",
+            "sha1": "1f87dd12387d98051ab9da39c03d1c20acb00a9b",
+            "root": "environments-7df1593053bc3b50bd2ff8acfaec2dd3f4aabbd3"
           }
         }
       }


### PR DESCRIPTION
the purpose of this pr:
-  is to support a new toolchain within our environment in order to allow tipi to build on windows-2022 machines.
- is to update environment in order to have a basic toolchain for docker ubuntu 24.04
- is to have a reclient that allows ar and ranlib to be used on the cluster : 
  - action run : https://github.com/EngFlow/reclient-private/actions/runs/15826456337
  - Commit : https://github.com/EngFlow/reclient-private/commit/770568aca0a998f58af81ad7e1aca1066cf95ab5 (last commit on main branch)
  
  
  Superseed:
  - https://github.com/tipi-build/distro/pull/69
  - https://github.com/tipi-build/distro/pull/68
  - https://github.com/tipi-build/distro/pull/67