### PR TITLE
🔧 use linux-cxx17 static target

### DIFF
--- a/distro.json
+++ b/distro.json
@@ -71,9 +71,9 @@
       "platforms": {
         "all": {
           "universal": {
-            "url": "https://github.com/tipi-build/environments/archive/7df1593053bc3b50bd2ff8acfaec2dd3f4aabbd3.zip",
-            "sha1": "1f87dd12387d98051ab9da39c03d1c20acb00a9b",
-            "root": "environments-7df1593053bc3b50bd2ff8acfaec2dd3f4aabbd3"
+            "url": "https://github.com/tipi-build/environments/archive/32eb00947daeb391dca3742412cb223770c8fb7c.zip",
+            "sha1": "42eaeff6f988b88f0d8f10eaf1acf14dc3b3b5d0",
+            "root": "environments-32eb00947daeb391dca3742412cb223770c8fb7c"
           }
         }
       }


### PR DESCRIPTION
The purpose of the pr is to be able to compile statically with the linux-cxx17 target.