### PR TITLE
:new: TIPI-1391: support alternative operators representations or, and, not...

### DIFF
--- a/distro.json
+++ b/distro.json
@@ -367,17 +367,17 @@
       "name": "reclient",
       "platforms": {
         "macos": {
-          "aarch64": {
-            "url": "https://storage.googleapis.com/engflow-tools-public/reclient/770568aca0a998f58af81ad7e1aca1066cf95ab5/reclient-770568aca0a998f58af81ad7e1aca1066cf95ab5-macos-arm64.zip",
-            "sha1": "dfc57b04c4dc93068d7082f8d972901181cd0a21",
+          "universal": {
+            "url": "https://storage.googleapis.com/engflow-tools-public/reclient/5d6649862cbf668566f67f426a9bb692b6c78e2f/reclient-5d6649862cbf668566f67f426a9bb692b6c78e2f-macos-arm64.zip",
+            "sha1": "dc8ae79e37aaf6bf6ea630e711b2a3533d2a235f",
             "root": "",
             "path": ["."]
           }
         },
         "linux": {
           "x86_64": {
-            "url": "https://storage.googleapis.com/engflow-tools-public/reclient/770568aca0a998f58af81ad7e1aca1066cf95ab5/reclient-770568aca0a998f58af81ad7e1aca1066cf95ab5-linux-x86_64.zip",
-            "sha1": "631eb904a0285520cb01d722e652e4b318a2d65e",
+            "url": "https://storage.googleapis.com/engflow-tools-public/reclient/5d6649862cbf668566f67f426a9bb692b6c78e2f/reclient-5d6649862cbf668566f67f426a9bb692b6c78e2f-linux-x86_64.zip",
+            "sha1": "8f1e7ade685fb2983d8448e7f3eb807228a00e12",
             "root": "",
             "path": ["."]
           }


### PR DESCRIPTION
Adds hidden predefined macros for all altnernative tokens in C++ mode, as in C++ those are valid tokens but not in C this only defines them in C++ mode independently of the standard version.

Despite C++20 first fully dropped the compatibility header <ciso646>, g++ supports the alternative token independently of the C++ standard version and the C <iso646.h> doesn't define any of those as macros when the compiler is in __cplusplus mode.

The rationale to behave equivalently on gcc/clang and MSVC is because we are targetting standard conformance as a future-proof implementation choice.

Indeed while MSVC only supports the alternative operators in `/permissive-` standard conformance mode, Visual Studio default settings for new C++ projects have `/permissive-` ON, therefore we do not implement a specific MSVC behaviour as it seems bound to disappear in favor of the C++ standard behaviour.

Fix tipi-build/specs-cmake-re#144